### PR TITLE
Issue #17502: Remove double slash in Site URL

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -144,6 +144,16 @@ Import-Package: javax.annotation;version=0.0.0,*
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>5.1.9</version>
+                    <inherited>true</inherited>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schemaapp.core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -103,7 +103,8 @@ Import-Package: javax.annotation;version=0.0.0,*
                         <_plugin>
                             <!-- Enable registration of Sling Models classes via bnd plugin -->
                             org.apache.sling.bnd.models.ModelsScannerPlugin,
-                                                                                    <!-- Allow the processing of SCR annotations via a bnd plugin --> org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir=${project.build.outputDirectory}
+                            <!-- Allow the processing of SCR annotations via a bnd plugin -->
+                            org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir=${project.build.outputDirectory}
                         </_plugin>
                         <!-- Include sling mapper configuration file -->
                         <Sling-Initial-Content>

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import javax.jcr.Session;
 
+import com.schemaapp.core.util.UrlUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -273,7 +274,8 @@ public class CDNDataProcessorImpl implements CDNDataProcessor {
                 String nodeName = "schemaapp";
                 ValueMap properties = new ValueMapDecorator(new HashMap<String, Object>());
                 properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "schemaApp/components/content/entitydata");
-                properties.put(Constants.SITEURL, siteURL + child.getPath());
+                properties.put(Constants.SITEURL,
+                        UrlUtils.concatSiteUrlPath(siteURL, child.getPath()));
 
                 // Create the node
                 resourceResolver.create(parentNode, nodeName, properties);
@@ -285,7 +287,8 @@ public class CDNDataProcessorImpl implements CDNDataProcessor {
 
                 if (map != null) {
                     map.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "schemaApp/components/content/entitydata");
-                    map.put(Constants.SITEURL, siteURL + child.getPath());
+                    map.put(Constants.SITEURL,
+                            UrlUtils.concatSiteUrlPath(siteURL, child.getPath()));
                     
                     LOG.debug("Schema App update node, updating existing node, node path {}", nodePath);
                 }

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
@@ -211,11 +211,10 @@ public class CDNDataProcessorImpl implements CDNDataProcessor {
      * @param configDetailMap The configuration details.
      * @return The extracted account ID.
      */
-    private String extractAccountId(ValueMap configDetailMap) {
-        String accountId = configDetailMap != null ? configDetailMap.get("accountID", String.class) : StringUtils.EMPTY;
-        if (accountId != null && accountId.lastIndexOf('/') > 0) {
-            int index = accountId.lastIndexOf('/');
-            accountId = accountId.substring(index + 1);
+    protected String extractAccountId(ValueMap configDetailMap) {
+        String accountId = configDetailMap != null ? configDetailMap.get("accountID", StringUtils.EMPTY) : StringUtils.EMPTY;
+        if (StringUtils.isNotBlank(accountId)) {
+            return accountId.replaceFirst("http.+/db/", "");
         }
         return accountId;
     }

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNHandlerServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNHandlerServiceImpl.java
@@ -7,6 +7,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import com.schemaapp.core.util.UrlUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -319,7 +320,8 @@ public class CDNHandlerServiceImpl implements CDNHandlerService {
     private void setSiteURLProperty(SchemaAppConfig config, Node pageNode, Resource urlResource)
             throws RepositoryException {
         if (StringUtils.isNotEmpty(config.getSiteURL())) {
-            pageNode.setProperty(Constants.SITEURL, config.getSiteURL() + urlResource.getPath());
+            pageNode.setProperty(Constants.SITEURL,
+					UrlUtils.concatSiteUrlPath(config.getSiteURL(), urlResource.getPath()));
         }
     }
 

--- a/core/src/main/java/com/schemaapp/core/util/UrlUtils.java
+++ b/core/src/main/java/com/schemaapp/core/util/UrlUtils.java
@@ -6,6 +6,13 @@ public final class UrlUtils {
 
     private UrlUtils() {}
 
+    /**
+     * Concatenates the site URL (the domain) and a path to a page, removing a trailing / if one
+     * exists after the site URL.
+     * @param siteUrl The site URL
+     * @param path The path to the page
+     * @return String of the concatenated siteUrl and path.
+     */
     public static String concatSiteUrlPath(String siteUrl, String path) {
         if (StringUtils.endsWith(siteUrl, "/") && StringUtils.startsWith(path, "/")) {
             return StringUtils.removeEnd(siteUrl, "/") + path;

--- a/core/src/main/java/com/schemaapp/core/util/UrlUtils.java
+++ b/core/src/main/java/com/schemaapp/core/util/UrlUtils.java
@@ -1,0 +1,16 @@
+package com.schemaapp.core.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public final class UrlUtils {
+
+    private UrlUtils() {}
+
+    public static String concatSiteUrlPath(String siteUrl, String path) {
+        if (StringUtils.endsWith(siteUrl, "/") && StringUtils.startsWith(path, "/")) {
+            return StringUtils.removeEnd(siteUrl, "/") + path;
+        }
+        return siteUrl + path;
+    }
+
+}

--- a/core/src/test/java/com/schemaapp/core/services/impl/CDNDataProcessorImplTest.java
+++ b/core/src/test/java/com/schemaapp/core/services/impl/CDNDataProcessorImplTest.java
@@ -1,0 +1,39 @@
+package com.schemaapp.core.services.impl;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.testing.resourceresolver.MockValueMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class CDNDataProcessorImplTest {
+
+    @InjectMocks
+    private CDNDataProcessorImpl cdnDataProcessor;
+    
+    @Mock
+    private Resource resource;
+
+    @Test
+    void testExtractAccountId() {
+        assertEquals("", cdnDataProcessor.extractAccountId(null));
+
+        ValueMap valueMap = new MockValueMap(resource);
+        assertEquals("", cdnDataProcessor.extractAccountId(valueMap));
+
+        valueMap.put("accountID", "http://schemaapp.com/db/AEMTest");
+        assertEquals("AEMTest", cdnDataProcessor.extractAccountId(valueMap));
+
+        valueMap.put("accountID", "https://schemaapp.com/db/AEMTest");
+        assertEquals("AEMTest", cdnDataProcessor.extractAccountId(valueMap));
+
+        valueMap.put("accountID", "http://schemaapp.com/db/AcmeDataTest/AEMTest");
+        assertEquals("AcmeDataTest/AEMTest", cdnDataProcessor.extractAccountId(valueMap));
+    }
+}

--- a/core/src/test/java/com/schemaapp/core/util/UrlUtilsTest.java
+++ b/core/src/test/java/com/schemaapp/core/util/UrlUtilsTest.java
@@ -1,0 +1,20 @@
+package com.schemaapp.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UrlUtilsTest {
+
+    @Test
+    public void testConcatSiteTrailingSlash() {
+        String result = UrlUtils.concatSiteUrlPath("https://testurl.com/", "/content/en/us/test");
+        assertEquals("https://testurl.com/content/en/us/test", result);
+    }
+
+    @Test
+    public void testConcatSiteNoTrailingSlash() {
+        String result = UrlUtils.concatSiteUrlPath("https://testurl.com", "/content/en/us/test");
+        assertEquals("https://testurl.com/content/en/us/test", result);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -783,19 +783,19 @@
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-databind</artifactId>
-			    <version>2.12.5</version> <!-- Ensure you have a version >= 2.12.0 -->
+			    <version>2.12.7</version> <!-- Ensure you have a version >= 2.12.0 -->
 			</dependency>
 			
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-core</artifactId>
-			    <version>2.12.5</version>
+			    <version>2.12.7</version>
 			</dependency>
 			
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-annotations</artifactId>
-			    <version>2.12.5</version>
+			    <version>2.12.7</version>
 			</dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.schemaapp</groupId>
     <artifactId>schemaapp-aem</artifactId>
     <packaging>pom</packaging>
-   	<version>2.0.3</version>
+   	<version>2.0.4</version>
     <url>https://www.schemaapp.com</url>
     <description>A connector to enable local caching of Schema Markup produced by Schema App.</description>
     <name>Schema App connector</name>  

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.3</version>
+       <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.3</version>
+       <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/schemaApp/components/content/entitydata/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/schemaApp/components/content/entitydata/.content.xml
@@ -3,5 +3,4 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:Component"
           jcr:title="Entity Data Component"
-		  sling:resourceSuperType="core/wcm/components/teaser/v1/teaser"
           componentGroup="SchemaApp Components"/>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
          <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
# type(scope): if this commit is applied, it will...
Resolve issues with the Site URL containing double slashes

# Why was this change made?

Resolves the issue with Site URL properties containing a double / between the domain and path to the page.

# Links to any relevant tickets, articles, or other resources

closes [#issue](https://github.com/SchemaApp/SchemaApp/issues/17502)

# Other Notes

Did you fix any additional issues or do you have special notes for the reviewer? Put them here.

# Suggested Test for Reviewer

1. Login to Schema app dashboard
2. Go to 
3. Do action
4. See result 
