### PR TITLE
Updated fasterxml jackson version to 2.16.2 

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schemaapp.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.schemaapp</groupId>
     <artifactId>schemaapp-aem</artifactId>
     <packaging>pom</packaging>
-   	<version>2.0.4</version>
+   	<version>2.0.5</version>
     <url>https://www.schemaapp.com</url>
     <description>A connector to enable local caching of Schema Markup produced by Schema App.</description>
     <name>Schema App connector</name>  
@@ -783,19 +783,19 @@
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-databind</artifactId>
-			    <version>2.14.3</version>
+			    <version>2.16.2</version>
 			</dependency>
 
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-core</artifactId>
-			    <version>2.14.3</version>
+			    <version>2.16.2</version>
 			</dependency>
 
 			<dependency>
 			    <groupId>com.fasterxml.jackson.core</groupId>
 			    <artifactId>jackson-annotations</artifactId>
-			    <version>2.14.3</version>
+			    <version>2.16.2</version>
 			</dependency>
 
         </dependencies>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.4</version>
+       <version>2.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.4</version>
+       <version>2.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
          <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Updated fasterxml jackson version to 2.16.2 to resolve security issues identified in #20237. Incremented the version of the connector to 2.0.5.

# type(scope): if this commit is applied, it will...
Resolve the issue reported in #20237.

# Why was this change made?
Requested change related to automated dependency checker.

# Links to any relevant tickets, articles, or other resources

closes [#20237](https://github.com/SchemaApp/SchemaApp/issues/20237)

# Other Notes

N/A

# Suggested Test for Reviewer

Regression test the connector
