### PR TITLE
Distribution Event Listener

### DIFF
--- a/Handling CDN Cache Clearing.md
+++ b/Handling CDN Cache Clearing.md
@@ -1,0 +1,86 @@
+# Using Event Handlers to Clear CDN Caches
+The Schema App will publish the jcr:content/schemaapp node on pages as they are returned by the API so they can be embedded within the content to be rendered. If your organization has content cached via a CDN that sits in front of Dispatcher, it may be necessary to implement a cache clearing solution within AEM.
+
+This can be best handled by using an Event Handler. A couple of examples can be found below:
+
+## When Using AEM 6.5.X  
+These instances use Replication to publish content between author and publish environments, so the handler that is implemented will need to listen to Replication events.
+
+```java
+import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+
+@Component(
+        service = EventHandler.class,
+        property = {
+                EventConstants.EVENT_TOPIC + "=" + ReplicationAction.EVENT_TOPIC
+        }
+)
+public class ReplicationEventHandler implements EventHandler {
+
+    private static final String SCHEMA_NODE = "jcr:content/schemaapp";
+
+    @Override
+    public void handleEvent(Event event) {
+        ReplicationAction action = ReplicationAction.fromEvent(event);
+
+        if (action.getType() == ReplicationActionType.ACTIVATE) {
+            String path = action.getPath();
+            if (path.endsWith(SCHEMA_NODE)) {
+                /*
+                 * TODO: Implement call to Sling Job or OSGi Service
+                 *  that will trigger CDN cache clear for the containing page
+                 */
+            }
+        }
+    }
+}
+```
+
+## When Using AEMaaCS  
+As AEM as a Cloud Service does not utilize Replication, but instead relies on Sling Content Distribution to publish content, a slightly different Event Handler will need to be implemented.
+
+```java
+import org.apache.commons.lang3.Strings;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_PATHS;
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_TYPE;
+import static org.apache.sling.distribution.event.DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED;
+
+@Component(
+        service = EventHandler.class,
+        property = {
+                EventConstants.EVENT_TOPIC + "=" + AGENT_PACKAGE_DISTRIBUTED
+        }
+)
+public class DistributionEventHandler implements EventHandler {
+
+    private static final String ADD_TYPE = "ADD";
+    private static final String SCHEMA_NODE = "jcr:content/schemaapp";
+
+    @Override
+    public void handleEvent(Event event) {
+        String[] paths = (String[]) event.getProperty(DISTRIBUTION_PATHS);
+        String type = (String) event.getProperty(DISTRIBUTION_TYPE);
+
+        if (Strings.CS.equals(type, ADD_TYPE) && paths != null) {
+            for (String path : paths) {
+                if (path.endsWith(SCHEMA_NODE)) {
+                    /*
+                     * TODO: Implement call to Sling Job or OSGi Service
+                     *  that will trigger CDN cache clear for the containing page
+                     */
+                }
+            }
+        }
+    }
+}
+```

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -159,6 +159,7 @@ Import-Package: javax.annotation;version=0.0.0,*
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- Testing -->
         <dependency>
@@ -211,6 +212,7 @@ Import-Package: javax.annotation;version=0.0.0,*
       	<dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
+          <scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
@@ -225,13 +227,8 @@ Import-Package: javax.annotation;version=0.0.0,*
 		    <artifactId>jackson-annotations</artifactId>
 		</dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,11 +148,11 @@ Import-Package: javax.annotation;version=0.0.0,*
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>uk.org.lidalia</groupId>
-            <artifactId>slf4j-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>uk.org.lidalia</groupId>-->
+<!--            <artifactId>slf4j-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>aem-sdk-api</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schemaapp.core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,24 +148,17 @@ Import-Package: javax.annotation;version=0.0.0,*
     </build>
 
     <dependencies>
-<!--        <dependency>-->
-<!--            <groupId>uk.org.lidalia</groupId>-->
-<!--            <artifactId>slf4j-test</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>aem-sdk-api</artifactId>
 		</dependency>
-<!--        Temp commenting out this dependency-->
-<!--         <dependency>-->
-<!--		  <groupId>org.apache.httpcomponents</groupId>-->
-<!--		  <artifactId>httpclient</artifactId>-->
-<!--		</dependency>-->
+         <dependency>
+		  <groupId>org.apache.httpcomponents</groupId>
+		  <artifactId>httpclient</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>
-            <scope>test</scope>
         </dependency>
         <!-- Testing -->
         <dependency>
@@ -207,20 +200,18 @@ Import-Package: javax.annotation;version=0.0.0,*
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.impl</artifactId>
-            <version>1.4.14</version>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
-<!--        Testing dropping JUnit-->
-<!--        <dependency>-->
-<!--           <groupId>org.apache.sling</groupId>-->
-<!--           <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>-->
-<!--           <scope>test</scope>-->
-<!--      	</dependency>-->
-<!--      	<dependency>-->
-<!--          <groupId>junit</groupId>-->
-<!--          <artifactId>junit</artifactId>-->
-<!--		</dependency>-->
-<!--        I think we need to keep this one for all the fasterxml stuff-->
+        <dependency>
+           <groupId>org.apache.sling</groupId>
+           <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+           <scope>test</scope>
+      	</dependency>
+      	<dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+		</dependency>
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
@@ -233,6 +224,15 @@ Import-Package: javax.annotation;version=0.0.0,*
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-annotations</artifactId>
 		</dependency>
-
+        <dependency>
+            <groupId>uk.org.lidalia</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/com/schemaapp/core/models/CDNEntityResult.java
+++ b/core/src/main/java/com/schemaapp/core/models/CDNEntityResult.java
@@ -1,7 +1,5 @@
 package com.schemaapp.core.models;
 
-import com.google.common.base.Objects;
-
 /**
  * The <code>WebhookEntityResult</code> class to prepare Webhook API response.
  * 
@@ -51,11 +49,10 @@ class WebhookEntitySucessResult extends CDNEntityResult {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
-				.add(ID_CONSTANT, id)
-				.add(TYPE_CONSTANT, type)
-				.add(SUCCESS_MESSAGE, "Successfully, request completed!")
-				.toString();
+		return "WebhookEntitySucessResult{"
+				+ ID_CONSTANT+"="+id+", "
+				+ TYPE_CONSTANT+"="+type+", "
+				+ SUCCESS_MESSAGE+"=Successfully, request completed!}";
 	}
 }
 
@@ -74,8 +71,6 @@ class WebhookEntityErrorResult extends CDNEntityResult {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
-				.add(ERROR_MESSAGE, errorMessage)
-				.toString();
+		return "WebhookEntityErrorResult{"+ERROR_MESSAGE+"="+errorMessage+"}";
 	}
 }

--- a/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import javax.jcr.RepositoryException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import com.day.cq.replication.ReplicationException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
 import com.schemaapp.core.models.SchemaAppConfig;
 import com.schemaapp.core.services.BulkDataLoaderAPIService;
 import com.schemaapp.core.services.CDNHandlerService;
@@ -189,7 +188,7 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
                 logger.debug("is existing :: {}", existing);
                 
                 String path = getContentPagePath(pageUri);
-                if (Strings.isNullOrEmpty(path) || "/".equals(path)) continue;
+                if (StringUtils.isBlank(path) || "/".equals(path)) continue;
                 newPages.add(path);
 
                 //if (!existing) {
@@ -199,7 +198,7 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
                     String eTagAEM = schemaappResource != null ? schemaappResource.getValueMap().get(Constants.E_TAG, StringUtils.EMPTY) : StringUtils.EMPTY;
                     String eTag = pageData.get("schemamodel:etag") != null ? pageData.get("schemamodel:etag").asText() : null;
 
-                    if (Strings.isNullOrEmpty(eTag) || !eTagAEM.equals(eTag)) {
+                    if (StringUtils.isBlank(eTag) || !eTagAEM.equals(eTag)) {
                         processDifferentETagsPages(pageData, path, resourceResolver, config);
                     } else {
                         existing = true;

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNHandlerServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNHandlerServiceImpl.java
@@ -14,7 +14,6 @@ import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -25,8 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.day.cq.replication.ReplicationException;
-import com.day.cq.replication.Replicator;
-import com.day.cq.search.QueryBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.schemaapp.core.models.SchemaAppConfig;
 import com.schemaapp.core.services.CDNHandlerService;
@@ -40,19 +37,9 @@ public class CDNHandlerServiceImpl implements CDNHandlerService {
 	private static final String SCHEMA_APP_COMPONENTS_RESOURCE_TYPE = "schemaApp/components/content/entitydata";
 
 	@Reference
-	ResourceResolverFactory resolverFactory;
-
-	@Reference
-	private QueryBuilder builder;
-
-	@Reference
 	FlushService flushService;
 
-	@Reference
-	Replicator replicator;
-	
     public static Logger logger = LoggerFactory.getLogger(CDNHandlerServiceImpl.class);
-
 
 	/**
 	 * Save Graph Data to AEM Node

--- a/core/src/main/java/com/schemaapp/core/services/impl/FlushServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/FlushServiceImpl.java
@@ -66,7 +66,7 @@ public class FlushServiceImpl implements FlushService {
         LOGGER.info("Starting Dispatcher cache invalidation for node: {}", nodePath);
         try {
             DistributionRequest distributionRequest = new SimpleDistributionRequest(
-                    DistributionRequestType.INVALIDATE, //This may need to use DistributionRequestType.ADD instead to actually publish the node
+                    DistributionRequestType.ADD,
                     false,
                     nodePath
             );

--- a/core/src/main/java/com/schemaapp/core/services/impl/FlushServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/FlushServiceImpl.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -19,14 +18,12 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.distribution.*;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.day.cq.replication.ReplicationActionType;
-import com.day.cq.replication.ReplicationException;
-import com.day.cq.replication.Replicator;
 import com.day.cq.wcm.api.Page;
 import com.schemaapp.core.services.FlushService;
 import com.schemaapp.core.util.ReplicationConstants;
@@ -38,12 +35,12 @@ public class FlushServiceImpl implements FlushService {
 
     @Reference
     private transient ResourceResolverFactory resolverFactory;
-    
+
     @Reference
-    private Replicator replicator;
+    private Distributor distributor;
 
     /**
-     * Invalidates the JSON cache for a specified page URL by triggering replication.
+     * Invalidates the JSON cache for a specified page URL by triggering distribution.
      *
      * @param pageUrl the URL of the page to invalidate in the Dispatcher cache
      */
@@ -51,18 +48,7 @@ public class FlushServiceImpl implements FlushService {
     public void invalidatePageJson(String pageUrl) {
         LOGGER.debug("invalidatePageJson start for page URL: {}", pageUrl);
         try (ResourceResolver resourceResolver = getResourceResolver()) {
-            Session session = resourceResolver.adaptTo(Session.class);
-            if (session != null) {
-                flushDispatcherForNode(session, pageUrl);
-                Resource publishReplicationAgentResource = resourceResolver.getResource(ReplicationConstants.REPLICATION_AGENT_PATH_PUBLISH);
-                if (publishReplicationAgentResource != null) {
-                    getResourceNode(publishReplicationAgentResource, pageUrl);
-                } else {
-                    LOGGER.warn("Publish replication agent resource is null.");
-                }
-            } else {
-                LOGGER.error("Session could not be retrieved from resource resolver.");
-            }
+                flushDispatcherForNode(resourceResolver, pageUrl);
         } catch (LoginException e) {
             LOGGER.error("LoginException occurred while accessing the resource resolver:", e);
         } catch (Exception e) {
@@ -71,88 +57,32 @@ public class FlushServiceImpl implements FlushService {
     }
     
     /**
-     * Initiates Dispatcher cache invalidation for a specific node by triggering replication.
+     * Initiates Dispatcher cache invalidation for a specific node by triggering distribution.
      *
-     * @param session the JCR session used to access the repository
+     * @param resourceResolver the ResourceResolver used to access the repository
      * @param nodePath the path of the node to invalidate in the cache
      */
-    private void flushDispatcherForNode(Session session, String nodePath) {
+    private void flushDispatcherForNode(ResourceResolver resourceResolver, String nodePath) {
         LOGGER.info("Starting Dispatcher cache invalidation for node: {}", nodePath);
         try {
-            replicator.replicate(session, ReplicationActionType.ACTIVATE, nodePath);
-            LOGGER.info("Cache invalidation successful for node: {}", nodePath);
-        } catch (ReplicationException e) {
-            LOGGER.error("ReplicationException during cache invalidation for node {}: {}", nodePath, e.getMessage(), e);
+            DistributionRequest distributionRequest = new SimpleDistributionRequest(
+                    DistributionRequestType.INVALIDATE, //This may need to use DistributionRequestType.ADD instead to actually publish the node
+                    false,
+                    nodePath
+            );
+
+            DistributionResponse response = distributor.distribute(
+                    ReplicationConstants.DISTRIBUTION_AGENT_NAME_PUBLISH,
+                    resourceResolver,
+                    distributionRequest);
+
+            if (response.isSuccessful()) {
+                LOGGER.info("Cache invalidation successful for node: {}", nodePath);
+            } else {
+                LOGGER.error("Cache invalidation failure for node: {}", nodePath);
+            }
         } catch (Exception e) {
             LOGGER.error("Unexpected exception during cache invalidation for node {}: {}", nodePath, e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Retrieves content resource nodes from the publish replication agent and invalidates
-     * the Dispatcher cache for the specified page URL.
-     *
-     * @param publishReplicationAgentResource the publish replication agent resource
-     * @param pageUrl the URL of the page to invalidate in the Dispatcher cache
-     */
-    private void getResourceNode(Resource publishReplicationAgentResource, String pageUrl) {
-        Page publishReplicationAgentPage = publishReplicationAgentResource.adaptTo(Page.class);
-        if (publishReplicationAgentPage != null) {
-            Iterator<Page> publishAgentPageIterator = publishReplicationAgentPage.listChildren();
-            while (publishAgentPageIterator.hasNext()) {
-                Page childPage = publishAgentPageIterator.next();
-                Resource contentResource = childPage.getContentResource();
-                Node contentResourceNode = contentResource != null ? contentResource.adaptTo(Node.class) : null;
-                if (contentResourceNode != null) {
-                    try {
-                        if (contentResourceNode.hasProperty("transportUri")) {
-                            String dispatcherCacheUrl = contentResourceNode.getProperty("transportUri").getString();
-                            LOGGER.debug("Dispatcher Cache URL: {}", dispatcherCacheUrl);
-                            invalidateDispatcherCache(pageUrl, dispatcherCacheUrl);
-                        }
-                    } catch (RepositoryException e) {
-                        LOGGER.error("RepositoryException in retrieving transportUri property:", e);
-                    }
-                }
-            }
-        } else {
-            LOGGER.warn("Publish replication agent page could not be adapted.");
-        }
-    }
-
-    /**
-     * Sends an HTTP request to invalidate the Dispatcher cache for the specified page.
-     *
-     * @param pagePath the path of the page to invalidate
-     * @param dispatcherCacheUrl the Dispatcher cache URL for invalidation
-     */
-    public void invalidateDispatcherCache(String pagePath, String dispatcherCacheUrl) {
-        if (pagePath != null && dispatcherCacheUrl != null) {
-            LOGGER.debug("Starting Dispatcher cache invalidation for page: {}", pagePath);
-            HttpGet request = new HttpGet(dispatcherCacheUrl);
-            try {
-                HttpClient client = HttpClientBuilder.create()
-                        .setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(10000).setSocketTimeout(10000).build())
-                        .build();
-                request.addHeader(ReplicationConstants.CQ_ACTION_HEADER, ReplicationConstants.ACTIVATE);
-                request.addHeader(ReplicationConstants.CQ_HANDLE_HEADER, pagePath);
-                request.addHeader(ReplicationConstants.CQ_PATH, pagePath);
-                
-                HttpResponse response = client.execute(request);
-                int statusCode = response.getStatusLine().getStatusCode();
-                LOGGER.debug("Dispatcher invalidation response code: {}", statusCode);
-                if (statusCode != HttpStatus.SC_OK) {
-                    LOGGER.warn("Dispatcher invalidation returned status code: {} for page: {}", statusCode, pagePath);
-                } else {
-                    LOGGER.info("Dispatcher cache successfully invalidated for page: {}", pagePath);
-                }
-            } catch (IOException e) {
-                LOGGER.error("IOException during Dispatcher cache invalidation for page {}: {}", pagePath, e.getMessage(), e);
-            } finally {
-                request.releaseConnection();
-            }
-        } else {
-            LOGGER.warn("Page path or Dispatcher cache URL is null. Cannot invalidate cache.");
         }
     }
 

--- a/core/src/main/java/com/schemaapp/core/util/ReplicationConstants.java
+++ b/core/src/main/java/com/schemaapp/core/util/ReplicationConstants.java
@@ -3,6 +3,7 @@ package com.schemaapp.core.util;
 public final class ReplicationConstants {
 
 	public static final String REPLICATION_AGENT_PATH_PUBLISH = "/etc/replication/agents.publish";
+	public static final String DISTRIBUTION_AGENT_NAME_PUBLISH = "publish";
 	public static final Object MODEL = null;
 	public static final String CQ_ACTION_HEADER = "CQ-Action";
 	public static final String CQ_HANDLE_HEADER = "CQ-Handle";

--- a/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
+++ b/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
@@ -158,35 +158,42 @@ public class BulkDataLoaderAPIServiceTest {
         when(rootNode.get("member")).thenReturn(memberNode);
         when(memberNode.isArray()).thenReturn(true);
 
-        when(fieldNames.hasNext()).thenReturn(true, false); // Simulate one element in the array
-        when(fieldNames.next()).thenReturn("https://experience.adobe.com/content/testpag.html"); 
-        when(memberNode.fieldNames()).thenReturn(fieldNames);
-        when(memberNode.get("https://experience.adobe.com/content/testpag.html")).thenReturn(pageData);
-
-        when(pageData.get(anyString())).thenReturn(pageData);
-        when(pageData.asText()).thenReturn("testData");
+        JsonNode objectNode = mock(JsonNode.class);
         Iterator<JsonNode> mockIterator = mock(Iterator.class);
-        when(mockIterator.hasNext()).thenReturn(true, false); // Simulate one element
-        when(mockIterator.next()).thenReturn(memberNode); // Provide mock object node
-        when(memberNode.elements()).thenReturn(mockIterator); // Return mock iterator
+        when(mockIterator.hasNext()).thenReturn(true, false);
+        when(mockIterator.next()).thenReturn(objectNode);
+        when(memberNode.iterator()).thenReturn(mockIterator);
 
-        
-        List<String> newPages =  new ArrayList();
+        Iterator<String> objectFieldNames = mock(Iterator.class);
+        when(objectFieldNames.hasNext()).thenReturn(true, false);
+        when(objectFieldNames.next()).thenReturn("https://experience.adobe.com/content/testpag.html");
+        when(objectNode.fieldNames()).thenReturn(objectFieldNames);
+
+        when(objectNode.get("https://experience.adobe.com/content/testpag.html")).thenReturn(pageData);
+
+        when(pageData.get("schemamodel:etag")).thenReturn(pageData);
+        when(pageData.get("schemamodel:source")).thenReturn(pageData);
+        when(pageData.get("aws:lastUpdated")).thenReturn(pageData);
+        when(pageData.get("@graph")).thenReturn(pageData);
+        when(pageData.asText()).thenReturn("testData");
+        when(pageData.toString()).thenReturn("{\"test\":\"data\"}");
+
+        when(resourceResolver.getResource(anyString())).thenReturn(null);
+
+        List<String> newPages = new ArrayList<>();
         newPages.add("/content/testpage");
 
         bulkDataLoaderAPIService.processJsonData(rootNode, newPages, resourceResolver, config);
 
         // Assert
-        // Verify that the interactions with mocks occurred as expected
         verify(rootNode).get("member");
         verify(memberNode).isArray();
-        verify(memberNode).elements();
+        verify(memberNode).iterator();
+        verify(objectNode).fieldNames();
 
-        // Add meaningful assertions based on your logic (example)
         assertNotNull(newPages);
         assertEquals(2, newPages.size());
         assertTrue(newPages.contains("/content/testpage"));
-
     }
 
 

--- a/core/src/test/java/com/schemaapp/core/services/FlushServiceImplTest.java
+++ b/core/src/test/java/com/schemaapp/core/services/FlushServiceImplTest.java
@@ -1,35 +1,26 @@
 package com.schemaapp.core.services;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Iterator;
-
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
 import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.distribution.DistributionRequest;
+import org.apache.sling.distribution.DistributionResponse;
+import org.apache.sling.distribution.Distributor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.day.cq.wcm.api.Page;
 import com.schemaapp.core.services.impl.FlushServiceImpl;
 
 public class FlushServiceImplTest {
@@ -44,40 +35,10 @@ public class FlushServiceImplTest {
     private ResourceResolver resourceResolver;
 
     @Mock
-    private Resource publishReplicationAgentResource;
+    private Distributor distributor;
 
     @Mock
-    private Resource contentResource;
-
-    @Mock
-    private Node contentResourceNode;
-
-    @Mock
-    private Page publishReplicationAgentPage;
-
-    @Mock
-    private Page childPage;
-
-    @Mock
-    private HttpClient httpClient;
-
-    @Mock
-    private HttpResponse httpResponse;
-
-    @Mock
-    private Iterator<Page> pageIterator;
-
-    @Mock
-    private Property property;
-
-    @Mock
-    private Value value;
-
-    @Mock
-    private Session session;
-    
-    @Mock
-    private StatusLine statusLine;
+    private DistributionResponse distributionResponse;
     
     @BeforeEach
     public void setUp() throws LoginException {
@@ -86,56 +47,47 @@ public class FlushServiceImplTest {
         
         // Mock ResourceResolver retrieval
         when(resolverFactory.getServiceResourceResolver(anyMap())).thenReturn(resourceResolver);
-        when(resourceResolver.adaptTo(Session.class)).thenReturn(session);
     }
 
     @Test
     public void testInvalidatePageJsonSuccess() throws LoginException {
         // Arrange
-        when(resourceResolver.getResource(anyString())).thenReturn(publishReplicationAgentResource);
-        when(publishReplicationAgentResource.adaptTo(Page.class)).thenReturn(publishReplicationAgentPage);
-        when(publishReplicationAgentPage.listChildren()).thenReturn(pageIterator);
-        when(pageIterator.hasNext()).thenReturn(false);
+        when(distributor.distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class)))
+                .thenReturn(distributionResponse);
+        when(distributionResponse.isSuccessful()).thenReturn(true);
 
         // Act
         flushService.invalidatePageJson("/content/testPage");
 
         // Assert
-        verify(publishReplicationAgentResource, times(1)).adaptTo(Page.class);
+        verify(distributor, times(1)).distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class));
     }
 
     @Test
-    public void testInvalidatePageJsonResourceNull() throws LoginException {
+    public void testInvalidatePageJsonFailure() throws LoginException {
         // Arrange
-        when(resourceResolver.getResource(anyString())).thenReturn(null);
+        when(distributor.distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class)))
+                .thenReturn(distributionResponse);
+        when(distributionResponse.isSuccessful()).thenReturn(false);
 
         // Act
         flushService.invalidatePageJson("/content/testPage");
 
         // Assert
-        verify(publishReplicationAgentResource, never()).adaptTo(Page.class);
+        verify(distributor, times(1)).distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class));
     }
 
     @Test
-    public void testGetResourceNodeSuccess() throws RepositoryException, LoginException {
+    public void testInvalidatePageJsonException() throws LoginException {
         // Arrange
-        when(resourceResolver.getResource(anyString())).thenReturn(publishReplicationAgentResource);
-        when(publishReplicationAgentResource.adaptTo(Page.class)).thenReturn(publishReplicationAgentPage);
-        when(publishReplicationAgentPage.listChildren()).thenReturn(pageIterator);
-        when(pageIterator.hasNext()).thenReturn(true, false);
-        when(pageIterator.next()).thenReturn(childPage);
-        when(childPage.getContentResource()).thenReturn(contentResource);
-        when(contentResource.adaptTo(Node.class)).thenReturn(contentResourceNode);
-        when(contentResourceNode.hasProperty("transportUri")).thenReturn(true);
-        when(contentResourceNode.getProperty("transportUri")).thenReturn(property);
-        when(property.getValue()).thenReturn(value);
-        when(value.getString()).thenReturn("http://dispatcher/cache");
+        when(distributor.distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class)))
+                .thenThrow(new RuntimeException("Distribution failed"));
 
         // Act
         flushService.invalidatePageJson("/content/testPage");
 
         // Assert
-        verify(contentResourceNode, times(1)).getProperty("transportUri");
+        verify(distributor, times(1)).distribute(eq("publish"), eq(resourceResolver), any(DistributionRequest.class));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
-        <core.wcm.components.version>2.28.0</core.wcm.components.version>
+        <core.wcm.components.version>2.30.4</core.wcm.components.version>
         <bnd.version>6.4.0</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -591,6 +591,7 @@ Bundle-DocURL:
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
                 <version>${core.wcm.components.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- I think we need this -->
@@ -689,9 +690,9 @@ Bundle-DocURL:
 			    <version>2.16.2</version>
 			</dependency>
             <dependency>
-                <groupId>uk.org.lidalia</groupId>
+                <groupId>com.github.valfirst</groupId>
                 <artifactId>slf4j-test</artifactId>
-                <version>1.0.1</version>
+                <version>3.0.3</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -702,23 +703,16 @@ Bundle-DocURL:
             </dependency>
 
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.0.1-jre</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
-                <version>2.4.0</version>
+                <version>3.6.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.1</version>
-<!--                <scope>test</scope>-->
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -685,12 +685,12 @@ Bundle-DocURL:
 			    <artifactId>jackson-annotations</artifactId>
 			    <version>2.16.2</version>
 			</dependency>
-            <dependency>
-                <groupId>uk.org.lidalia</groupId>
-                <artifactId>slf4j-test</artifactId>
-                <version>1.0.1</version>
-                <scope>test</scope>
-            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>uk.org.lidalia</groupId>-->
+<!--                <artifactId>slf4j-test</artifactId>-->
+<!--                <version>1.0.1</version>-->
+<!--                <scope>test</scope>-->
+<!--            </dependency>-->
 
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.schemaapp</groupId>
     <artifactId>schemaapp-aem</artifactId>
     <packaging>pom</packaging>
-   	<version>2.0.5-SNAPSHOT</version>
+   	<version>2.0.6-SNAPSHOT</version>
     <url>https://www.schemaapp.com</url>
     <description>A connector to enable local caching of Schema Markup produced by Schema App.</description>
     <name>Schema App connector</name>  

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <id>coverage-initialize</id>
@@ -361,7 +361,7 @@ Bundle-DocURL:
                 <plugin>
                     <groupId>com.day.jcr.vault</groupId>
                     <artifactId>content-package-maven-plugin</artifactId>
-          <version>1.0.6</version>
+                    <version>1.0.6</version>
                     <configuration>
                         <targetURL>http://${aem.host}:${aem.port}/crx/packmgr/service.jsp</targetURL>
                         <failOnError>true</failOnError>
@@ -583,8 +583,8 @@ Bundle-DocURL:
         <dependencies>
             <dependency>
                 <groupId>com.adobe.aem</groupId>
-        <artifactId>aem-sdk-api</artifactId>
-        <version>${aem.sdk.api}</version>
+                <artifactId>aem-sdk-api</artifactId>
+                <version>${aem.sdk.api}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -610,13 +610,13 @@ Bundle-DocURL:
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.1.0</version>
+                <version>5.18.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>4.1.0</version>
+                <version>5.18.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -628,16 +628,19 @@ Bundle-DocURL:
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>5.5.4</version>
+                <version>5.1.2</version>
                 <scope>test</scope>
                 <exclusions>
+                    <exclusion>
+                        <groupId>xerces</groupId>
+                        <artifactId>xercesImpl</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.scripting.api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
@@ -685,13 +688,38 @@ Bundle-DocURL:
 			    <artifactId>jackson-annotations</artifactId>
 			    <version>2.16.2</version>
 			</dependency>
-<!--            <dependency>-->
-<!--                <groupId>uk.org.lidalia</groupId>-->
-<!--                <artifactId>slf4j-test</artifactId>-->
-<!--                <version>1.0.1</version>-->
-<!--                <scope>test</scope>-->
-<!--            </dependency>-->
+            <dependency>
+                <groupId>uk.org.lidalia</groupId>
+                <artifactId>slf4j-test</artifactId>
+                <version>1.0.1</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.0.1-jre</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+                <version>2.4.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.1</version>
+<!--                <scope>test</scope>-->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
          <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.0.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
# type(scope): if this commit is applied, it will...
Add support for publishing/clearing the cache via a Distribution Event (AEMaaCS version of replication)

# Why was this change made?
To ensure clients on AEMaaCS can have their cache cleared when the connector pulls back data from SchemaApp.

Feature request? A bug was found? Doing some refactoring? Let us know why this should be in our codebase.
Feature parity between AEMaaCS and standalone versions of the codebase.

# Links to any relevant tickets, articles, or other resources

closes #issue

# Other Notes

Did you fix any additional issues or do you have special notes for the reviewer? Put them here.

# Suggested Test for Reviewer
Full regression test of the connector on the AEMaaCS instance in Cloud Manager

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cache invalidation behavior changes materially for AEMaaCS (distribution-only, no direct Dispatcher HTTP flush), so stale or missed cache clears are possible if the publish agent or paths are misconfigured. Broader dependency and SDK bumps add regression surface beyond the flush path alone.
> 
> **Overview**
> **Dispatcher/cache invalidation on AEM as a Cloud Service** now goes through Sling Content Distribution instead of classic replication and manual Dispatcher HTTP flush.
> 
> `FlushServiceImpl` drops `Replicator`, replication-agent traversal, and `invalidateDispatcherCache` HTTP calls. It issues an `ADD` `SimpleDistributionRequest` on the `publish` distribution agent via `Distributor`, with `ReplicationConstants.DISTRIBUTION_AGENT_NAME_PUBLISH` added. `CDNHandlerServiceImpl` no longer wires unused replication/query/resolver factory dependencies.
> 
> A new **`Handling CDN Cache Clearing.md`** documents optional OSGi event handlers for customers: replication events on 6.5 vs `AGENT_PACKAGE_DISTRIBUTED` on AEMaaCS when `jcr:content/schemaapp` is published (CDN clear left as TODO in the samples).
> 
> The release is bumped to **2.0.6-SNAPSHOT** with AEM SDK, WCM components, Mockito, JaCoCo, and test stack updates; Guava is removed from `CDNEntityResult` and string checks move to Apache Commons Lang3 in bulk load. Unit tests for flush and bulk JSON processing are aligned with the new distribution flow and JSON iteration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a816eb2e34af990533c8cb588189057b5643ad9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->