### PR TITLE
Adding Proxy Support for connections to the Schema backend

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schemaapp.core</artifactId>

--- a/core/src/main/java/com/schemaapp/core/models/SchemaAppConfig.java
+++ b/core/src/main/java/com/schemaapp/core/models/SchemaAppConfig.java
@@ -1,5 +1,7 @@
 package com.schemaapp.core.models;
 
+import org.apache.sling.api.resource.ValueMap;
+
 public class SchemaAppConfig {
 
     private String accountId;
@@ -22,17 +24,17 @@ public class SchemaAppConfig {
 
     private String proxyPassword;
 
-    public SchemaAppConfig(String accountId, String siteURL, String deploymentMethod, String endpoint, String apiKey, boolean enableProxy, String proxyHost, String proxyPort, String proxyUsername, String proxyPassword) {
+    public SchemaAppConfig(String accountId, String endpoint, ValueMap configDetailMap) {
         this.accountId = accountId;
-        this.siteURL = siteURL;
-        this.deploymentMethod = deploymentMethod;
+        this.siteURL = configDetailMap.get("siteURL", String.class);
+        this.deploymentMethod = configDetailMap.get("deploymentMethod", String.class);
         this.endpoint = endpoint;
-        this.apiKey = apiKey;
-        this.enableProxy = enableProxy;
-        this.proxyHost = proxyHost;
-        this.proxyPort = proxyPort;
-        this.proxyUsername = proxyUsername;
-        this.proxyPassword = proxyPassword;
+        this.apiKey = configDetailMap.get("apiKey", String.class);
+        this.enableProxy = configDetailMap.get("enableProxy", false);
+        this.proxyHost = configDetailMap.get("proxyHost", String.class);
+        this.proxyPort = configDetailMap.get("proxyPort", String.class);
+        this.proxyUsername = configDetailMap.get("proxyUsername", String.class);
+        this.proxyPassword = configDetailMap.get("proxyPassword", String.class);
     }
 
     public SchemaAppConfig() {

--- a/core/src/main/java/com/schemaapp/core/models/SchemaAppConfig.java
+++ b/core/src/main/java/com/schemaapp/core/models/SchemaAppConfig.java
@@ -12,12 +12,27 @@ public class SchemaAppConfig {
     
     private String apiKey;
 
-    public SchemaAppConfig(String accountId, String siteURL, String deploymentMethod, String endpoint, String apiKey) {
+    private boolean enableProxy;
+
+    private String proxyHost;
+
+    private String proxyPort;
+
+    private String proxyUsername;
+
+    private String proxyPassword;
+
+    public SchemaAppConfig(String accountId, String siteURL, String deploymentMethod, String endpoint, String apiKey, boolean enableProxy, String proxyHost, String proxyPort, String proxyUsername, String proxyPassword) {
         this.accountId = accountId;
         this.siteURL = siteURL;
         this.deploymentMethod = deploymentMethod;
         this.endpoint = endpoint;
         this.apiKey = apiKey;
+        this.enableProxy = enableProxy;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.proxyUsername = proxyUsername;
+        this.proxyPassword = proxyPassword;
     }
 
     public SchemaAppConfig() {
@@ -61,5 +76,45 @@ public class SchemaAppConfig {
 
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    public boolean isEnableProxy() {
+        return enableProxy;
+    }
+
+    public void setEnableProxy(boolean enableProxy) {
+        this.enableProxy = enableProxy;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public String getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(String proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    public void setProxyUsername(String proxyUsername) {
+        this.proxyUsername = proxyUsername;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
     }
 }

--- a/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
@@ -133,10 +133,12 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
                 && StringUtils.isNotBlank(config.getProxyPort()) && NumberUtils.isDigits(config.getProxyPort())) {
 
             // Proxy configuration is available, create a proxy-aware HttpClient
+            logger.info("Proxy configuration is available, creating proxy-aware HttpClient");
             HttpHost proxy = new HttpHost(config.getProxyHost(), Integer.parseInt(config.getProxyPort()));
 
             if (StringUtils.isNotBlank(config.getProxyUsername()) && StringUtils.isNotBlank(config.getProxyPassword())) {
                 // Proxy authentication is available, set up credentials provider
+                logger.info("Proxy authentication is available, setting up credentials provider");
                 CredentialsProvider credsProvider = new BasicCredentialsProvider();
                 credsProvider.setCredentials(
                         new AuthScope(proxy.getHostName(), proxy.getPort()),
@@ -149,6 +151,9 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
             }
         }
         // No proxy configuration, use default HttpClient
+        logger.info("No proxy configuration, using default HttpClient");
+        logger.info("Proxy Enabled: {}, Proxy Host: {}, Proxy Port: {} & is digits {}",
+                config.isEnableProxy(), config.getProxyHost(), config.getProxyPort(), NumberUtils.isDigits(config.getProxyPort()));
         return HttpClients.createDefault();
     }
 

--- a/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/BulkDataLoaderAPIServiceImpl.java
@@ -1,26 +1,25 @@
 package com.schemaapp.core.services.impl;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.jcr.RepositoryException;
-
+import com.day.cq.replication.ReplicationException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.schemaapp.core.models.SchemaAppConfig;
+import com.schemaapp.core.services.BulkDataLoaderAPIService;
+import com.schemaapp.core.services.CDNHandlerService;
+import com.schemaapp.core.util.Constants;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
@@ -33,14 +32,14 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.day.cq.replication.ReplicationException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
-import com.schemaapp.core.models.SchemaAppConfig;
-import com.schemaapp.core.services.BulkDataLoaderAPIService;
-import com.schemaapp.core.services.CDNHandlerService;
-import com.schemaapp.core.util.Constants;
+import javax.jcr.RepositoryException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES;
 
 @Component(service = BulkDataLoaderAPIService.class, immediate = true)
 public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
@@ -68,7 +67,7 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
             List<String> newPages = new ArrayList<>();
             existing = false;
             while (nextPage != null) {
-                String response = executeApiRequest(config.getApiKey(), nextPage);
+                String response = executeApiRequest(config, nextPage);
                 if (response == null) break;
                 JsonNode rootNode = parseJsonResponse(response);
 
@@ -91,14 +90,14 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
     /**
      * Executes an API request and returns the response as a string.
      *
-     * @param apiKey The API key.
+     * @param config The SchemaApp configuration.
      * @param url    The URL to execute the request.
      * @return The API response as a string.
      */
-    public String executeApiRequest(String apiKey, String url) {
-        try (CloseableHttpClient client = getClient()) {
+    public String executeApiRequest(SchemaAppConfig config, String url) {
+        try (CloseableHttpClient client = getClient(config)) {
             HttpGet httpGet = new HttpGet(URI.create(url));
-            httpGet.addHeader("x-api-key", apiKey);
+            httpGet.addHeader("x-api-key", config.getApiKey());
 
             try (CloseableHttpResponse response = client.execute(httpGet)) {
                 int statusCode = response.getStatusLine().getStatusCode();
@@ -124,7 +123,32 @@ public class BulkDataLoaderAPIServiceImpl implements BulkDataLoaderAPIService {
     }
 
 
-    public CloseableHttpClient getClient() {
+    /**
+     * Creates a CloseableHttpClient instance based on the configuration.
+     * @param config The SchemaApp configuration.
+     * @return CloseableHttpClient instance
+     */
+    public CloseableHttpClient getClient(SchemaAppConfig config) {
+        if (config.isEnableProxy() && StringUtils.isNotBlank(config.getProxyHost())
+                && StringUtils.isNotBlank(config.getProxyPort()) && NumberUtils.isDigits(config.getProxyPort())) {
+
+            // Proxy configuration is available, create a proxy-aware HttpClient
+            HttpHost proxy = new HttpHost(config.getProxyHost(), Integer.parseInt(config.getProxyPort()));
+
+            if (StringUtils.isNotBlank(config.getProxyUsername()) && StringUtils.isNotBlank(config.getProxyPassword())) {
+                // Proxy authentication is available, set up credentials provider
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(
+                        new AuthScope(proxy.getHostName(), proxy.getPort()),
+                        new UsernamePasswordCredentials(config.getProxyUsername(), config.getProxyPassword())
+                );
+                return HttpClients.custom().setProxy(proxy).setDefaultCredentialsProvider(credsProvider).build();
+            } else {
+                // No proxy authentication, use default credentials provider
+                return HttpClients.custom().setProxy(proxy).build();
+            }
+        }
+        // No proxy configuration, use default HttpClient
         return HttpClients.createDefault();
     }
 

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
@@ -173,12 +173,17 @@ public class CDNDataProcessorImpl implements CDNDataProcessor {
                 String siteURL = configDetailMap.get("siteURL", String.class);
                 String deploymentMethod = configDetailMap.get("deploymentMethod", String.class);
                 String apiKey = configDetailMap.get("apiKey", String.class);
+                boolean enableProxy = configDetailMap.get("enableProxy", false);
+                String proxyHost = configDetailMap.get("proxyHost", String.class);
+                String proxyPort = configDetailMap.get("proxyPort", String.class);
+                String proxyUsername = configDetailMap.get("proxyUsername", String.class);
+                String proxyPassword = configDetailMap.get("proxyPassword", String.class);
                 
                 Iterator<Page> childPages = page.listChildren(new PageFilter(), true);
                 String endpoint = ConfigurationUtil.getConfiguration(Constants.SCHEMAAPP_DATA_API_ENDPOINT_KEY,
                         Constants.API_ENDPOINT_CONFIG_PID, configurationAdmin, "");
 
-                SchemaAppConfig config = new SchemaAppConfig(accountId, siteURL, deploymentMethod, endpoint, apiKey);
+                SchemaAppConfig config = new SchemaAppConfig(accountId, siteURL, deploymentMethod, endpoint, apiKey, enableProxy, proxyHost, proxyPort, proxyUsername, proxyPassword);
                 while (childPages.hasNext()) {
                     createOrUpdateSchemaNode(childPages, resolver, siteURL);
                 }

--- a/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
+++ b/core/src/main/java/com/schemaapp/core/services/impl/CDNDataProcessorImpl.java
@@ -171,19 +171,12 @@ public class CDNDataProcessorImpl implements CDNDataProcessor {
             if (configDetailMap != null) {
                 String accountId = extractAccountId(configDetailMap);
                 String siteURL = configDetailMap.get("siteURL", String.class);
-                String deploymentMethod = configDetailMap.get("deploymentMethod", String.class);
-                String apiKey = configDetailMap.get("apiKey", String.class);
-                boolean enableProxy = configDetailMap.get("enableProxy", false);
-                String proxyHost = configDetailMap.get("proxyHost", String.class);
-                String proxyPort = configDetailMap.get("proxyPort", String.class);
-                String proxyUsername = configDetailMap.get("proxyUsername", String.class);
-                String proxyPassword = configDetailMap.get("proxyPassword", String.class);
-                
+
                 Iterator<Page> childPages = page.listChildren(new PageFilter(), true);
                 String endpoint = ConfigurationUtil.getConfiguration(Constants.SCHEMAAPP_DATA_API_ENDPOINT_KEY,
                         Constants.API_ENDPOINT_CONFIG_PID, configurationAdmin, "");
 
-                SchemaAppConfig config = new SchemaAppConfig(accountId, siteURL, deploymentMethod, endpoint, apiKey, enableProxy, proxyHost, proxyPort, proxyUsername, proxyPassword);
+                SchemaAppConfig config = new SchemaAppConfig(accountId, endpoint, configDetailMap);
                 while (childPages.hasNext()) {
                     createOrUpdateSchemaNode(childPages, resolver, siteURL);
                 }

--- a/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
+++ b/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
@@ -66,19 +66,19 @@ public class BulkDataLoaderAPIServiceTest {
 
     @Mock
     private JsonNode rootNode;
-    
+
     @Mock
     private JSONArray rootNodeArray;
 
     @Mock
     private JsonNode memberNode;
-    
+
     @Mock
     private JsonNode pageData;
 
     @Mock
     private ObjectMapper objectMapper;
-    
+
     @Mock
     private Iterator<String> fieldNames;
 
@@ -118,10 +118,10 @@ public class BulkDataLoaderAPIServiceTest {
 
         // Mock getClient to return mocked httpClient
         BulkDataLoaderAPIServiceImpl bulkDataLoaderAPIServiceSpy = spy(bulkDataLoaderAPIService);
-        doReturn(httpClient).when(bulkDataLoaderAPIServiceSpy).getClient();
+        doReturn(httpClient).when(bulkDataLoaderAPIServiceSpy).getClient(config);
 
         // Act
-        String result = bulkDataLoaderAPIServiceSpy.executeApiRequest("apiKey", "testUrl");
+        String result = bulkDataLoaderAPIServiceSpy.executeApiRequest(config, "testUrl");
 
         // Assert
         assertNotNull(result);
@@ -142,10 +142,10 @@ public class BulkDataLoaderAPIServiceTest {
 
         // Mock getClient to return mocked httpClient
         BulkDataLoaderAPIServiceImpl bulkDataLoaderAPIServiceSpy = spy(bulkDataLoaderAPIService);
-        doReturn(httpClient).when(bulkDataLoaderAPIServiceSpy).getClient();
+        doReturn(httpClient).when(bulkDataLoaderAPIServiceSpy).getClient(config);
 
         // Act
-        String result = bulkDataLoaderAPIServiceSpy.executeApiRequest("apiKey", "testUrl");
+        String result = bulkDataLoaderAPIServiceSpy.executeApiRequest(config, "testUrl");
 
         // Assert
         assertNull(result); // Ensure null is returned on failure
@@ -159,7 +159,7 @@ public class BulkDataLoaderAPIServiceTest {
         when(memberNode.isArray()).thenReturn(true);
 
         when(fieldNames.hasNext()).thenReturn(true, false); // Simulate one element in the array
-        when(fieldNames.next()).thenReturn("https://experience.adobe.com/content/testpag.html"); 
+        when(fieldNames.next()).thenReturn("https://experience.adobe.com/content/testpag.html");
         when(memberNode.fieldNames()).thenReturn(fieldNames);
         when(memberNode.get("https://experience.adobe.com/content/testpag.html")).thenReturn(pageData);
 
@@ -170,7 +170,7 @@ public class BulkDataLoaderAPIServiceTest {
         when(mockIterator.next()).thenReturn(memberNode); // Provide mock object node
         when(memberNode.elements()).thenReturn(mockIterator); // Return mock iterator
 
-        
+
         List<String> newPages =  new ArrayList();
         newPages.add("/content/testpage");
 
@@ -195,7 +195,7 @@ public class BulkDataLoaderAPIServiceTest {
         // Mock the behavior of rootNode and viewNode
         JsonNode viewNode = mock(JsonNode.class);
         JsonNode nextNode = mock(JsonNode.class);
-        
+
         when(rootNode.get("view")).thenReturn(viewNode);
         when(viewNode.has("next")).thenReturn(true);
         when(viewNode.get("next")).thenReturn(nextNode);
@@ -208,6 +208,133 @@ public class BulkDataLoaderAPIServiceTest {
         assertEquals("https://api.schemaapp.comnextPage", nextPage);
     }
 
+
+    // ==========================================================
+    // Tests for getClient(SchemaAppConfig) - covering all branches
+    // ==========================================================
+
+    @Test
+    public void testGetClient_NoProxyEnabled_ReturnsDefaultClient() {
+        // isEnableProxy() -> false, short-circuits entire outer if
+        when(config.isEnableProxy()).thenReturn(false);
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_BlankHost_ReturnsDefaultClient() {
+        // isEnableProxy() true but proxyHost blank -> default client
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_NullHost_ReturnsDefaultClient() {
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn(null);
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_BlankPort_ReturnsDefaultClient() {
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_NonNumericPort_ReturnsDefaultClient() {
+        // Port present but not digits -> NumberUtils.isDigits false -> default
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("abcd");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_NoAuth_ReturnsProxyClient() {
+        // Valid proxy, no credentials -> proxy client without credentials provider
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("8080");
+        when(config.getProxyUsername()).thenReturn("");
+        // Password lookup short-circuits due to blank username
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_NullUsername_ReturnsProxyClientWithoutAuth() {
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("8080");
+        when(config.getProxyUsername()).thenReturn(null);
+        // Password lookup should short-circuit; keep it lenient by not stubbing
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_UsernameOnly_ReturnsProxyClientWithoutAuth() {
+        // Username set but password blank -> partial pass, no auth branch
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("8080");
+        when(config.getProxyUsername()).thenReturn("user");
+        when(config.getProxyPassword()).thenReturn("");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_WithAuth_ReturnsAuthenticatedProxyClient() {
+        // Fully configured proxy with credentials -> auth branch
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("8080");
+        when(config.getProxyUsername()).thenReturn("user");
+        when(config.getProxyPassword()).thenReturn("secret");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testGetClient_ProxyEnabled_NumericPortBoundary() {
+        // Port with leading zeros - still digits
+        when(config.isEnableProxy()).thenReturn(true);
+        when(config.getProxyHost()).thenReturn("proxy.example.com");
+        when(config.getProxyPort()).thenReturn("0080");
+        when(config.getProxyUsername()).thenReturn("user");
+        when(config.getProxyPassword()).thenReturn("pass");
+
+        CloseableHttpClient client = bulkDataLoaderAPIService.getClient(config);
+
+        assertNotNull(client);
+    }
 
     @Test
     public void testRetrievePagePathsFromNode() {

--- a/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
+++ b/core/src/test/java/com/schemaapp/core/services/BulkDataLoaderAPIServiceTest.java
@@ -214,7 +214,7 @@ public class BulkDataLoaderAPIServiceTest {
     // ==========================================================
 
     @Test
-    public void testGetClient_NoProxyEnabled_ReturnsDefaultClient() {
+    public void testGetClientNoProxyEnabledReturnsDefaultClient() {
         // isEnableProxy() -> false, short-circuits entire outer if
         when(config.isEnableProxy()).thenReturn(false);
 
@@ -224,7 +224,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_BlankHost_ReturnsDefaultClient() {
+    public void testGetClientProxyEnabledBlankHostReturnsDefaultClient() {
         // isEnableProxy() true but proxyHost blank -> default client
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("");
@@ -235,7 +235,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_NullHost_ReturnsDefaultClient() {
+    public void testGetClientProxyEnabledNullHostReturnsDefaultClient() {
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn(null);
 
@@ -245,7 +245,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_BlankPort_ReturnsDefaultClient() {
+    public void testGetClientProxyEnabledBlankPortReturnsDefaultClient() {
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
         when(config.getProxyPort()).thenReturn("");
@@ -256,7 +256,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_NonNumericPort_ReturnsDefaultClient() {
+    public void testGetClientProxyEnabledNonNumericPortReturnsDefaultClient() {
         // Port present but not digits -> NumberUtils.isDigits false -> default
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
@@ -268,7 +268,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_NoAuth_ReturnsProxyClient() {
+    public void testGetClientProxyEnabledNoAuthReturnsProxyClient() {
         // Valid proxy, no credentials -> proxy client without credentials provider
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
@@ -282,7 +282,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_NullUsername_ReturnsProxyClientWithoutAuth() {
+    public void testGetClientProxyEnabledNullUsernameReturnsProxyClientWithoutAuth() {
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
         when(config.getProxyPort()).thenReturn("8080");
@@ -295,7 +295,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_UsernameOnly_ReturnsProxyClientWithoutAuth() {
+    public void testGetClientProxyEnabledUsernameOnlyReturnsProxyClientWithoutAuth() {
         // Username set but password blank -> partial pass, no auth branch
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
@@ -309,7 +309,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_WithAuth_ReturnsAuthenticatedProxyClient() {
+    public void testGetClientProxyEnabledWithAuthReturnsAuthenticatedProxyClient() {
         // Fully configured proxy with credentials -> auth branch
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");
@@ -323,7 +323,7 @@ public class BulkDataLoaderAPIServiceTest {
     }
 
     @Test
-    public void testGetClient_ProxyEnabled_NumericPortBoundary() {
+    public void testGetClientProxyEnabledNumericPortBoundary() {
         // Port with leading zeros - still digits
         when(config.isEnableProxy()).thenReturn(true);
         when(config.getProxyHost()).thenReturn("proxy.example.com");

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.schemaapp</groupId>
     <artifactId>schemaapp-aem</artifactId>
     <packaging>pom</packaging>
-   	<version>2.0.5</version>
+   	<version>2.0.6</version>
     <url>https://www.schemaapp.com</url>
     <description>A connector to enable local caching of Schema Markup produced by Schema App.</description>
     <name>Schema App connector</name>  

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.5</version>
+       <version>2.0.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.5</version>
+       <version>2.0.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
@@ -126,13 +126,13 @@
                                                         <proxyHost
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                            fieldDescription="Please provide the proxy host/URL, e.g https://www.mydomain.com."
-                                                            fieldLabel="Proxy Host "
+                                                            fieldDescription="Please provide the proxy hostname, e.g.: 127.9.9.1 or us.proxytest.net"
+                                                            fieldLabel="Proxy Hostname"
                                                             name="./proxyHost"/>
                                                         <proxyPort
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                            fieldDescription="Please provide the proxy port."
+                                                            fieldDescription="Please provide the proxy port, e.g.: 8080 or 5000
                                                             fieldLabel="Proxy Port"
                                                             name="./proxyPort"/>
                                                         <proxyUsername

--- a/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
@@ -115,13 +115,43 @@
 														            sling:resourceType="granite/ui/components/foundation/form/hidden"/>
 									                        </items>
 									                    </radiogroupA>
+                                                        <enableProxy
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                            name="./enableProxy"
+                                                            text="Enable Proxy"
+                                                            checked="{Boolean}false"
+                                                            uncheckedValue="{Boolean}false"
+                                                            value="{Boolean}true"/>
+                                                        <proxyHost
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldDescription="Please provide the proxy host/URL, e.g https://www.mydomain.com."
+                                                            fieldLabel="Proxy Host "
+                                                            name="./proxyHost"/>
+                                                        <proxyPort
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldDescription="Please provide the proxy port."
+                                                            fieldLabel="Proxy Port"
+                                                            name="./proxyPort"/>
+                                                        <proxyUsername
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldLabel="Proxy Username"
+                                                            name="./proxyUsername"/>
+                                                        <proxyPassword
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            fieldLabel="Proxy Password"
+                                                            name="./proxyPassword"/>
                                                         <connect
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/button"
                                                             text="Connect to Schema App"	
-                                                            granite:class="cq-confadmin-schema-app-connect"															
+                                                            granite:class="cq-confadmin-schema-app-connect"
 															variant="primary"
-                                                            name="./siteURL"/>                                                                        
+                                                            name="./siteURL"/>
                                                     </items>
                                                 </propColumn>
                                             </items>

--- a/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
@@ -142,7 +142,7 @@
                                                             name="./proxyUsername"/>
                                                         <proxyPassword
                                                             jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/password"
                                                             fieldLabel="Proxy Password"
                                                             name="./proxyPassword"/>
                                                         <connect

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
          <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
# type(scope): if this commit is applied, it will...
add the ability for clients to configure their proxy settings in the cloud configuration. When enabled, the proxy will be a part of the request made to the schema backend.

# Why was this change made?
USBank requested proxy support for their internal network. Odds are, other financial institutions will need similar functionality.

# Links to any relevant tickets, articles, or other resources

closes #issue

# Other Notes

Did you fix any additional issues or do you have special notes for the reviewer? Put them here.

# Suggested Test for Reviewer

1. Login to Schema app dashboard
2. Go to 
3. Do action
4. See result 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the outbound HTTP client path and handles proxy credentials from JCR cloud config; misconfiguration could break API sync, though proxy is opt-in and covered by new unit tests.
> 
> **Overview**
> **Release 2.0.6** adds **optional corporate HTTP proxy** support when the connector calls the Schema App export API, aimed at locked-down networks (e.g. financial institutions).
> 
> The **Schema App cloud configuration wizard** now exposes **Enable Proxy** plus host, port, username, and password fields. Those values are stored on the cloud service `jcr:content` node like other settings.
> 
> **`SchemaAppConfig`** is refactored to load site URL, deployment method, API key, and all proxy fields from a single **`ValueMap`**, and **`CDNDataProcessorImpl`** builds config with the new `(accountId, endpoint, configDetailMap)` constructor.
> 
> **`BulkDataLoaderAPIServiceImpl`** routes paginated export requests through **`getClient(SchemaAppConfig)`**: when proxy is enabled with a valid host and numeric port, Apache HttpClient uses that proxy, with **optional proxy basic auth** when both username and password are set; otherwise behavior stays the default direct client. **`executeApiRequest`** now takes the full config instead of only the API key.
> 
> Unit tests were updated for the new signatures and add branch coverage for proxy on/off, invalid proxy settings, and authenticated vs unauthenticated proxy clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0a9b65c3552cea87ab3171aa93ede909297ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->