### PR TITLE
Chore(Deployment): Migrate to modern central publishing plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,25 +57,19 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version> <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>ossrh</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
 		    <plugin>


### PR DESCRIPTION
# Chore(Deployment): Migrate to modern central publishing plugin

If this commit is applied, it will update the Maven Central publishing workflow of the AEM connector by replacing the decommissioned legacy `nexus-staging-maven-plugin` with the modern, officially recommended `central-publishing-maven-plugin`.

# Why was this change made?

Sonatype has deprecated its legacy OSSRH hosting instances (such as `s01.oss.sonatype.org`), which resulted in `404 - Not Found` connection failures when attempting to deploy new versions using the legacy staging plugin. 

To restore and modernize our deployment pipeline, this change:
* Removes the legacy `nexus-staging-maven-plugin` from the parent `pom.xml`.
* Removes deprecated distribution repository mappings from `<distributionManagement>`.
* Integrates the modern `central-publishing-maven-plugin` configured to target the new Sonatype Central Portal with `autoPublish` enabled.

# Links to any relevant tickets, articles, or other resources

* Sonatype Central Portal Publishing Guide: https://central.sonatype.org/publish/publish-portal-maven/
* Sonatype OSSRH API Deprecation updates.

# Other Notes

**Important for Deployers:**
To successfully run `mvn clean deploy` moving forward, any developer or CI/CD runner executing the release must update their local `~/.m2/settings.xml` file:
1. Ensure your GPG key fingerprint is declared in `<gpg.keyname>`.
2. Generate a new **User Token** from the modern portal at [central.sonatype.com](https://central.sonatype.com/) and use those generated token credentials in your server block under `<id>ossrh</id>` (legacy Jira passwords will no longer work).

# Suggested Test for Reviewer

Since this is a build configuration change, you can test and verify the integrity of the updated POM configuration locally:

1. Pull this branch and navigate to the project root directory.
2. Run a standard local build:
   ```bash
   mvn clean install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/release configuration only; no application runtime or security logic changes, though failed deploys are possible until CI and local Maven credentials match the new Central Portal requirements.
> 
> **Overview**
> **Migrates Maven Central deployment** from Sonatype’s deprecated OSSRH staging flow to the **Central Portal** publishing plugin so `mvn deploy` no longer hits retired `s01.oss.sonatype.org` endpoints.
> 
> In the parent `pom.xml`, the legacy **`nexus-staging-maven-plugin`** is removed and replaced with **`central-publishing-maven-plugin`** (`0.6.0`), using `publishingServerId` **`ossrh`** and **`autoPublish`** enabled. **`<distributionManagement>`** now only defines a snapshot repo at **`https://central.sonatype.com/repository/maven-snapshots/`**; the old release staging repository URL is dropped.
> 
> Release operators will need **Central Portal user tokens** (and updated `~/.m2/settings.xml` for the `ossrh` server id) before deploys succeed—runtime AEM connector code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c881f9e393b9ea54915708710f52723268453550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->