### PR TITLE
Added missing closing double quote in cloud config dialog.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schemaapp.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.schemaapp</groupId>
     <artifactId>schemaapp-aem</artifactId>
     <packaging>pom</packaging>
-   	<version>2.0.6</version>
+   	<version>2.0.6.1</version>
     <url>https://www.schemaapp.com</url>
     <description>A connector to enable local caching of Schema Markup produced by Schema App.</description>
     <name>Schema App connector</name>  

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.6</version>
+       <version>2.0.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-       <version>2.0.6</version>
+       <version>2.0.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/schemaApp/utilities/schemaAppcloudconfig/wizard/.content.xml
@@ -132,7 +132,7 @@
                                                         <proxyPort
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                            fieldDescription="Please provide the proxy port, e.g.: 8080 or 5000
+                                                            fieldDescription="Please provide the proxy port, e.g.: 8080 or 5000"
                                                             fieldLabel="Proxy Port"
                                                             name="./proxyPort"/>
                                                         <proxyUsername

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -23,7 +23,7 @@
     <parent>
          <groupId>com.schemaapp</groupId>
         <artifactId>schemaapp-aem</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
# type(scope): if this commit is applied, it will...
i.e. fix(login): [more detailed message]

# Why was this change made?

Feature request? A bug was found? Doing some refactoring? Let us know why this should be in our codebase.

# Links to any relevant tickets, articles, or other resources

closes #issue

# Other Notes

Did you fix any additional issues or do you have special notes for the reviewer? Put them here.

# Suggested Test for Reviewer

1. Login to Schema app dashboard
2. Go to 
3. Do action
4. See result 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-attribute XML fix plus version bump only; no runtime logic or security changes.
> 
> **Overview**
> Fixes **malformed JCR dialog XML** in the Schema App cloud service configuration wizard: the **Proxy Port** `fieldDescription` was missing its closing double quote, which could break XML parsing or Granite UI rendering for that dialog.
> 
> The release is tagged as **2.0.6.1** by updating the parent and module `pom.xml` versions (`schemaapp-aem`, `all`, `core`, `ui.apps`, `ui.apps.structure`, `ui.content`) from `2.0.6` to `2.0.6.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0dc8c492ebb503d2114a5c34593267c15e61499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->